### PR TITLE
Raise a BadRequest if the image id is invalid

### DIFF
--- a/coverart_redirect/request.py
+++ b/coverart_redirect/request.py
@@ -196,10 +196,10 @@ class CoverArtRedirect(object):
         try:
             image_id = int(possible_id)
         except ValueError:
-            raise NotFound ("id %s is not a valid cover image id" % (name))
+            raise BadRequest ("%s does not not contain a valid cover image id" % (filename))
 
         resultproxy = self.conn.execute (
-            query, { "mbid": mbid, "image_id": int(image_id) })
+            query, { "mbid": mbid, "image_id": image_id})
         row = resultproxy.fetchone ()
         resultproxy.close ()
         if row:

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -120,6 +120,12 @@ class All (unittest.TestCase):
         self.verifyRedirect (req + '-500.jpg', expected + '_thumb500.jpg')
 
 
+    def test_resolve_image_id_with_invalid_cover_image_id (self):
+        _id = "invalid"
+        response = self.server.get("release/353710ec-1509-4df9-8ce2-9bd5011e3b80/" + _id)
+        self.assertEqual (response.status, b'400 BAD REQUEST')
+
+
     def test_release_index (self):
 
         response = self.server.get ('/release/98f08de3-c91c-4180-a961-06c205e63669/')


### PR DESCRIPTION
Invalid in this case means it's neither an integer nor "front" or
"back". This was previously supposed to raise a NotFound but as there
can't be an image with an invalid id, a BadRequest makes more sense.
(The MusicBrainz server does also use 400 Bad Request if invalid values,
like invalid includes, are supplied.)

This also fixes [CAA-58](http://tickets.musicbrainz.org/browse/CAA-58).
