### PR TITLE
Correctly rewrite PDF thumbnail URLs

### DIFF
--- a/coverart_redirect/request.py
+++ b/coverart_redirect/request.py
@@ -328,8 +328,8 @@ class CoverArtRedirect(object):
         if not filename:
             return [statuscode (400), "no filename specified"]
 
-        filename = re.sub("-250.(jpg|gif|png)", "_thumb250.jpg", filename)
-        filename = re.sub("-500.(jpg|gif|png)", "_thumb500.jpg", filename)
+        filename = re.sub("-250.(jpg|gif|png|pdf)", "_thumb250.jpg", filename)
+        filename = re.sub("-500.(jpg|gif|png|pdf)", "_thumb500.jpg", filename)
 
         url = "%s/mbid-%s/mbid-%s-%s" % (self.config.s3.prefix, mbid, mbid, filename)
         return request.redirect (code=307, location=url)


### PR DESCRIPTION
Hank and one of his colleagues have been working on adding support for PDF thumbnails, which are expected to work like the other thumbnails (e.g. filename.ext -> filename_thumb500.jpg).

He says it hasn't been deployed to the production servers yet, but I'm guessing that this should be fine to merge already, since the URLs it currently redirects to for PDF thumbnails don't work anyway. Having caa.org redirecting correctly will make it a lot easier to test the musicbrainz-server parts too.
