### PR TITLE
Fix uWSGI configuration for clean shutdown

### DIFF
--- a/docker/prod/consul-template-redirect.conf
+++ b/docker/prod/consul-template-redirect.conf
@@ -5,7 +5,7 @@ template {
 }
 
 exec {
-    command = "chpst -u art:art /home/art/.local/bin/uwsgi /etc/uwsgi/uwsgi.ini"
+    command = ["chpst", "-u", "art:art", "/home/art/.local/bin/uwsgi", "/etc/uwsgi/uwsgi.ini"]
     splay = "10s"
     reload_signal = "SIGHUP"
     kill_signal = "SIGTERM"

--- a/docker/prod/uwsgi.ini
+++ b/docker/prod/uwsgi.ini
@@ -9,3 +9,6 @@ processes = 10
 die-on-term = true
 worker-reload-mercy = 10
 reload-mercy = 25
+log-x-forwarded-for=true
+; quit uwsgi if the python app fails to load
+need-app = true


### PR DESCRIPTION
In absence of the exit-on-reload configuration option, uWSGI does not exit cleanly when consul-template attempts to restart it. This manifests as an error like: `bind(): Address already in use [core/socket.c line 769]`. Fix the configuration appropriately.