### PR TITLE
Replaced 9999 with 158, the correct constant for EDIT_EVENT_ADD_EVENT_ART, as defined in the official MusicBrainz Server source

### DIFF
--- a/test/add_data.sql
+++ b/test/add_data.sql
@@ -27,8 +27,8 @@ INSERT INTO musicbrainz.editor (id, name, password, email, email_confirm_date, h
 VALUES (1, 'kuno', 'topsecret', 'kuno@kunoenterprises.ltd', now(), '');
 
 INSERT INTO musicbrainz.edit (id, editor, type, status, expire_time)
-    -- FIXME: replace 9999 with the "add event artwork" edit type ID, once that's known.
-    VALUES (1, 1, 314, 2, now()), (2, 1, 9999, 2, now());
+    -- edit type 314 = EDIT_RELEASE_ADD_COVER_ART, 158 = EDIT_EVENT_ADD_EVENT_ART
+    VALUES (1, 1, 314, 2, now()), (2, 1, 158, 2, now());
 INSERT INTO musicbrainz.edit_data (edit, data)
     VALUES (1, '{"foo":"bar"}'), (2, '{"foo":"bar"}');
 


### PR DESCRIPTION
## Abstract
Resolves a long-standing `FIXME` comment in the test SQL fixture by replacing
the placeholder edit type ID `9999` with the correct, verified value `158`
(`EDIT_EVENT_ADD_EVENT_ART`), sourced from the official MusicBrainz Server
constants file.

## Problem
In [test/add_data.sql], the `INSERT INTO musicbrainz.edit` statement used a
placeholder value of `9999` for the "add event artwork" edit type, with a
comment acknowledging that the real value was unknown at the time of writing: